### PR TITLE
Upgrade to work with roar > 1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 pkg/*
 *.DS_Store
 .env
+.ruby-version

--- a/Rakefile
+++ b/Rakefile
@@ -6,6 +6,7 @@ Rake::TestTask.new do |t|
   t.libs.push "lib"
   t.test_files = FileList['test/test_*.rb']
   t.verbose = true
+  t.warning = false
 end
 
 task :default => "test"

--- a/lib/prx/client.rb
+++ b/lib/prx/client.rb
@@ -9,9 +9,9 @@ module PRX
   module Client
 
     class << self
-      
+
       include PRX::Model
-      
+
       attr_accessor :key, :secret, :scheme, :host, :port, :version, :token
 
 
@@ -21,18 +21,18 @@ module PRX
         action = opts.delete(:action) || :get
         opts = default_options.merge(opts)
 
-        path = api_path(path) unless path.starts_with?('/')
+        path = api_path(path) unless path[0] == '/'
         response = access_token.send(action, path, opts)
         # puts response.inspect
         response
       end
 
       protected
-      
+
       def api_path(path)
         "/api/#{version}/#{path}"
       end
-      
+
       def access_token
         OAuth2::AccessToken.new(client, token, {})
       end
@@ -52,15 +52,15 @@ module PRX
       def site
         "#{scheme || 'http'}://#{host}:#{port}"
       end
-      
+
       def default_options
         {
           'Accept' => 'application/json',
           'Content-Type' => 'application/json'
         }
       end
-      
+
     end
-    
+
   end
 end

--- a/lib/prx/client/version.rb
+++ b/lib/prx/client/version.rb
@@ -1,5 +1,5 @@
 module PRX
   module Client
-    VERSION = "0.3.1"
+    VERSION = "1.0.0"
   end
 end

--- a/lib/prx/model.rb
+++ b/lib/prx/model.rb
@@ -8,3 +8,8 @@ require "prx/model/user"
 require "prx/model/producer"
 require "prx/model/license"
 require "prx/model/piece"
+
+module PRX
+  module Model
+  end
+end

--- a/lib/prx/model/account.rb
+++ b/lib/prx/model/account.rb
@@ -1,16 +1,13 @@
-require 'roar/representer/json'
 require 'prx/model/base'
 require 'prx/representer/full/account_representer'
 
 module PRX
   module Model
     class Account < PRX::Model::Base
-
-	  include Roar::Representer::JSON
+      include Roar::JSON
       include PRX::Representer::Full::AccountRepresenter
 
       attr_accessor :name, :path, :type_name
-
     end
   end
 end

--- a/lib/prx/model/audio_file.rb
+++ b/lib/prx/model/audio_file.rb
@@ -1,4 +1,3 @@
-require 'roar/representer/json'
 require 'prx/model/base'
 require 'prx/representer/full/audio_file_representer'
 
@@ -6,12 +5,12 @@ module PRX
   module Model
     class AudioFile < PRX::Model::Base
 
-      include Roar::Representer::JSON
+      include Roar::JSON
       include PRX::Representer::Full::AudioFileRepresenter
 
       attr_accessor :label, :content_type, :size, :status, :length, :url
       attr_reader :attach_file
-      
+
       def attach_file=(f)
         @attach_file = f
         prepare_file_upload if f

--- a/lib/prx/model/audio_version.rb
+++ b/lib/prx/model/audio_version.rb
@@ -1,4 +1,3 @@
-require 'roar/representer/json'
 require 'prx/model/base'
 require 'prx/representer/full/audio_version_representer'
 
@@ -6,7 +5,7 @@ module PRX
   module Model
     class AudioVersion < PRX::Model::Base
 
-      include Roar::Representer::JSON
+      include Roar::JSON
       include PRX::Representer::Full::AudioVersionRepresenter
 
       attr_accessor :label,:content_advisory,:timing_and_cues,:transcript,:news_hole_break,:floating_break,:bottom_of_hour_break,:twenty_forty_break,:audio_files

--- a/lib/prx/model/base.rb
+++ b/lib/prx/model/base.rb
@@ -1,7 +1,10 @@
+require 'roar/decorator'
+require 'roar/json'
+
 module PRX
   module Model
     class Base
-
+      include ActiveModel::Model
       attr_accessor :id
 
       def initialize(*args)
@@ -19,7 +22,7 @@ module PRX
         opts = {
           :action => (id ? :put : :post),
           :path   => (id ? "#{class_path_part}/#{id}" : class_path_part),
-          :body   => as_json
+          :body   => to_hash
         }
         response = request(opts)
         self.from_json(response.response.body)

--- a/lib/prx/model/license.rb
+++ b/lib/prx/model/license.rb
@@ -1,4 +1,3 @@
-require 'roar/representer/json'
 require 'prx/model/base'
 require 'prx/representer/full/license_representer'
 
@@ -6,7 +5,7 @@ module PRX
   module Model
     class License < PRX::Model::Base
 
-      include Roar::Representer::JSON
+      include Roar::JSON
       include PRX::Representer::Full::LicenseRepresenter
 
       attr_accessor :website_usage, :allow_edit, :additional_terms

--- a/lib/prx/model/network.rb
+++ b/lib/prx/model/network.rb
@@ -1,4 +1,3 @@
-require 'roar/representer/json'
 require 'prx/model/base'
 require 'prx/representer/full/network_representer'
 
@@ -6,7 +5,7 @@ module PRX
   module Model
     class Network < PRX::Model::Base
 
-      include Roar::Representer::JSON
+      include Roar::JSON
       include PRX::Representer::Full::NetworkRepresenter
 
       attr_accessor :name, :path

--- a/lib/prx/model/piece.rb
+++ b/lib/prx/model/piece.rb
@@ -1,4 +1,3 @@
-require 'roar/representer/json'
 require 'prx/model/base'
 require 'prx/representer/full/piece_representer'
 
@@ -6,7 +5,7 @@ module PRX
   module Model
     class Piece < PRX::Model::Base
 
-      include Roar::Representer::JSON
+      include Roar::JSON
       include PRX::Representer::Full::PieceRepresenter
 
       attr_accessor :title, :short_description, :description, :account_id, :published_at, :created_at, :produced_on

--- a/lib/prx/model/producer.rb
+++ b/lib/prx/model/producer.rb
@@ -1,4 +1,3 @@
-require 'roar/representer/json'
 require 'prx/model/base'
 require 'prx/representer/full/producer_representer'
 
@@ -6,7 +5,7 @@ module PRX
   module Model
     class Producer < PRX::Model::Base
 
-      include Roar::Representer::JSON
+      include Roar::JSON
       include PRX::Representer::Full::ProducerRepresenter
 
       attr_accessor :name, :email, :user

--- a/lib/prx/model/series.rb
+++ b/lib/prx/model/series.rb
@@ -1,13 +1,11 @@
 require 'prx/model/base'
 require 'prx/representer/full/series_representer'
 
-require 'roar/representer/json'
-
 module PRX
   module Model
     class Series < PRX::Model::Base
 
-      include Roar::Representer::JSON
+      include Roar::JSON
       include PRX::Representer::Full::SeriesRepresenter
 
       attr_accessor :title, :subscribable

--- a/lib/prx/model/user.rb
+++ b/lib/prx/model/user.rb
@@ -1,4 +1,3 @@
-require 'roar/representer/json'
 require 'prx/model/base'
 require 'prx/representer/full/user_representer'
 
@@ -6,7 +5,7 @@ module PRX
   module Model
     class User < PRX::Model::Base
 
-      include Roar::Representer::JSON
+      include Roar::JSON
       include PRX::Representer::Full::UserRepresenter
 
       attr_accessor :login, :email, :first_name, :last_name

--- a/lib/prx/representer.rb
+++ b/lib/prx/representer.rb
@@ -13,3 +13,7 @@ require "prx/representer/full/producer_representer"
 require "prx/representer/full/license_representer"
 require "prx/representer/full/piece_representer"
 
+module PRX
+  module Representer
+  end
+end

--- a/lib/prx/representer/full/account_representer.rb
+++ b/lib/prx/representer/full/account_representer.rb
@@ -1,19 +1,17 @@
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 module PRX
   module Representer
     module Full
       module AccountRepresenter
-        
-        include Roar::Representer::Feature::Hypermedia
-        include Roar::Representer::JSON
+        include Roar::JSON
+        include Roar::Hypermedia
 
         property :id
         property :name
         property :path
         property :type_name, :from=>:type
-        
       end
     end
   end

--- a/lib/prx/representer/full/audio_file_representer.rb
+++ b/lib/prx/representer/full/audio_file_representer.rb
@@ -1,15 +1,13 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 module PRX
   module Representer
     module Full
       module AudioFileRepresenter
+        include Roar::JSON
+        include Roar::Hypermedia
 
-        include Roar::Representer::Feature::Hypermedia
-        include Roar::Representer::JSON
-      
         property :id
         property :label
         property :attach_file
@@ -17,8 +15,7 @@ module PRX
         property :size
         property :status
         property :length
-        property :url, :if => lambda {|opts| opts[:link_audio]}      
-
+        property :url, :if => lambda {|opts| opts[:link_audio]}
       end
     end
   end

--- a/lib/prx/representer/full/audio_version_representer.rb
+++ b/lib/prx/representer/full/audio_version_representer.rb
@@ -1,15 +1,14 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
-require "prx/representer/full/audio_file_representer"
+require 'roar/json'
+require 'roar/hypermedia'
+require 'prx/model/audio_file'
+require 'prx/representer/full/audio_file_representer'
 
 module PRX
   module Representer
     module Full
       module AudioVersionRepresenter
-
-        include Roar::Representer::Feature::Hypermedia
-        include Roar::Representer::JSON
+        include Roar::JSON
+        include Roar::Hypermedia
 
         property :id
         property :label
@@ -24,7 +23,6 @@ module PRX
         collection  :audio_files,
                     :class  => PRX::Model::AudioFile,
                     :extend => PRX::Representer::Full::AudioFileRepresenter
-
       end
     end
   end

--- a/lib/prx/representer/full/license_representer.rb
+++ b/lib/prx/representer/full/license_representer.rb
@@ -1,14 +1,12 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 module PRX
   module Representer
     module Full
       module LicenseRepresenter
-
-        include Roar::Representer::Feature::Hypermedia
-        include Roar::Representer::JSON
+        include Roar::JSON
+        include Roar::Hypermedia
 
         property :id
         property :website_usage

--- a/lib/prx/representer/full/network_representer.rb
+++ b/lib/prx/representer/full/network_representer.rb
@@ -1,19 +1,16 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 module PRX
   module Representer
     module Full
       module NetworkRepresenter
-        
-        include Roar::Representer::Feature::Hypermedia
-        include Roar::Representer::JSON
+        include Roar::JSON
+        include Roar::Hypermedia
 
         property :id
         property :name
         property :path
-        
       end
     end
   end

--- a/lib/prx/representer/full/piece_representer.rb
+++ b/lib/prx/representer/full/piece_representer.rb
@@ -1,6 +1,13 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
+
+require "prx/model/audio_version"
+require "prx/model/license"
+require "prx/model/producer"
+require "prx/model/user"
+require "prx/model/account"
+require "prx/model/series"
+require "prx/model/network"
 
 require "prx/representer/min/account_representer"
 require "prx/representer/min/network_representer"
@@ -15,9 +22,8 @@ module PRX
   module Representer
     module Full
       module PieceRepresenter
-
-        include Roar::Representer::Feature::Hypermedia
-        include Roar::Representer::JSON
+        include Roar::JSON
+        include Roar::Hypermedia
 
         property :id
         property :title
@@ -43,7 +49,7 @@ module PRX
         property :point_level
         property :network_only
         property :publish_on_valid
-        
+
         # child models we provide full
         property    :promos,
                     :class  => PRX::Model::AudioVersion,
@@ -77,7 +83,6 @@ module PRX
         collection  :networks,
                     :class  => PRX::Model::Network,
                     :extend => PRX::Representer::Min::NetworkRepresenter
-
       end
     end
   end

--- a/lib/prx/representer/full/producer_representer.rb
+++ b/lib/prx/representer/full/producer_representer.rb
@@ -1,6 +1,5 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 require "prx/representer/min/user_representer"
 
@@ -8,9 +7,8 @@ module PRX
   module Representer
     module Full
       module ProducerRepresenter
-
-        include Roar::Representer::Feature::Hypermedia
-        include Roar::Representer::JSON
+        include Roar::JSON
+        include Roar::Hypermedia
 
         property :id
         property :name

--- a/lib/prx/representer/full/series_representer.rb
+++ b/lib/prx/representer/full/series_representer.rb
@@ -1,18 +1,15 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 module PRX
   module Representer
     module Full
       module SeriesRepresenter
-        
-        include Roar::Representer::Feature::Hypermedia
-        include Roar::Representer::JSON
+        include Roar::JSON
+        include Roar::Hypermedia
 
         property :id
         property :title
-        
       end
     end
   end

--- a/lib/prx/representer/full/user_representer.rb
+++ b/lib/prx/representer/full/user_representer.rb
@@ -1,21 +1,18 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 module PRX
   module Representer
     module Full
       module UserRepresenter
-        
-        include Roar::Representer::Feature::Hypermedia
-        include Roar::Representer::JSON
+        include Roar::JSON
+        include Roar::Hypermedia
 
         property :id
         property :login
         property :email
         property :first_name
         property :last_name
-        
       end
     end
   end

--- a/lib/prx/representer/min/account_representer.rb
+++ b/lib/prx/representer/min/account_representer.rb
@@ -1,19 +1,16 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
 
 module PRX
   module Representer
     module Min
       module AccountRepresenter
-        include Roar::Representer::JSON
-        # include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON
+        # include Roar::Hypermedia
 
         property :id
         property :name
         property :path
         property :type_name, :from=>:type
-
       end
     end
   end

--- a/lib/prx/representer/min/network_representer.rb
+++ b/lib/prx/representer/min/network_representer.rb
@@ -1,18 +1,17 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 module PRX
   module Representer
     module Min
       module NetworkRepresenter
-        include Roar::Representer::JSON
-        include Roar::Representer::Feature::Hypermedia
-      
+        include Roar::JSON
+        include Roar::Hypermedia
+
         property :id
         property :name
         property :path
-      
+
       end
     end
   end

--- a/lib/prx/representer/min/series_representer.rb
+++ b/lib/prx/representer/min/series_representer.rb
@@ -1,13 +1,12 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 module PRX
   module Representer
     module Min
       module SeriesRepresenter
-        include Roar::Representer::JSON
-        include Roar::Representer::Feature::Hypermedia
+        include Roar::JSON
+        include Roar::Hypermedia
 
         property :id
         property :title

--- a/lib/prx/representer/min/user_representer.rb
+++ b/lib/prx/representer/min/user_representer.rb
@@ -1,20 +1,19 @@
-require 'roar/representer'
-require 'roar/representer/json'
-require 'roar/representer/feature/hypermedia'
+require 'roar/json'
+require 'roar/hypermedia'
 
 module PRX
   module Representer
     module Min
       module UserRepresenter
-        include Roar::Representer::JSON
-        include Roar::Representer::Feature::Hypermedia
-      
+        include Roar::JSON
+        include Roar::Hypermedia
+
         property :id
         property :login
         property :email
         property :first_name
         property :last_name
-      
+
       end
     end
   end

--- a/lib/prx_client.rb
+++ b/lib/prx_client.rb
@@ -1,12 +1,9 @@
 require 'i18n'
 require 'oauth2'
 require 'json'
-
 require 'active_support'
-require 'active_support/core_ext'
-require 'active_support/core_ext/module'
-require 'active_support/core_ext/module/aliasing'
-require 'active_support/json/encoding'
-require 'active_support/all'
+require 'active_model'
 
 require 'prx/client/version'
+require 'prx/model'
+require 'prx/representer'

--- a/prx_client.gemspec
+++ b/prx_client.gemspec
@@ -18,15 +18,15 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency "json"
   s.add_runtime_dependency "activesupport"
+  s.add_runtime_dependency "activemodel"
   s.add_runtime_dependency "excon"
   s.add_runtime_dependency "oauth2"
   s.add_runtime_dependency 'faraday'
-  s.add_runtime_dependency "roar"
+  s.add_runtime_dependency "roar", '>= 1.0.0'
 
   # specify any dependencies here; for example:
   s.add_development_dependency "rake"
   s.add_development_dependency "test-unit"
   s.add_development_dependency 'webmock'
   s.add_development_dependency "dotenv"
-  
 end

--- a/test/test_account.rb
+++ b/test/test_account.rb
@@ -16,5 +16,5 @@ class PRX::TestAccount < Test::Unit::TestCase
     a = PRX::Model::Account.new(:name=>'n', :id=>1)
     assert_equal a.to_hash, {"name"=>"n", "id"=>1}
   end
-  
+
 end

--- a/test/test_audio_file.rb
+++ b/test/test_audio_file.rb
@@ -8,7 +8,7 @@ class PRX::TestAudioFile < Test::Unit::TestCase
   def test_initialize
     af = PRX::Model::AudioFile.new(:id=>1, :label=>'l', :size=>3000, :length=>30, :status=>'new', :content_type=>'audio/wav' )
     assert af.is_a?(PRX::Model::AudioFile)
-    assert af.as_json === {"label"=>"l", "size"=>3000, "content_type"=>"audio/wav", "id"=>1, "length"=>30, "status"=>"new"}
+    assert af.to_hash === {"label"=>"l", "size"=>3000, "content_type"=>"audio/wav", "id"=>1, "length"=>30, "status"=>"new"}
   end
 
   def test_default_content_type
@@ -20,5 +20,5 @@ class PRX::TestAudioFile < Test::Unit::TestCase
     af = PRX::Model::AudioFile.new(:attach_file=>"#{File.dirname(__FILE__)}/files/test.mp2")
     assert af.attach_file.is_a?(Faraday::UploadIO)
   end
-  
+
 end

--- a/test/test_audio_version.rb
+++ b/test/test_audio_version.rb
@@ -19,9 +19,9 @@ class PRX::TestAudioVersion < Test::Unit::TestCase
 
   def test_initialize_with_json
     json = {"label"=>"l", "audio_files"=>[{"label"=>"af"}]}.to_json
-    af = PRX::Model::AudioVersion.from_json(json)
+    af = PRX::Model::AudioVersion.new.from_json(json)
     assert af.is_a?(PRX::Model::AudioVersion)
     assert af.audio_files.first.is_a?(PRX::Model::AudioFile)
   end
-  
+
 end

--- a/test/test_client.rb
+++ b/test/test_client.rb
@@ -4,14 +4,14 @@ require 'prx/client'
 require 'prx/model'
 
 class PRX::TestClient < Test::Unit::TestCase
-  
-  def setup 
-    PRX::Client.key     = 'WlziaXf34NighkX24LjnE9JgpEmEQkP8nWkBmh9J'
-    PRX::Client.secret  = 'iuUWEb3AfS5DQiOVpqH1juAacQ0vr3aIhNGWfIW9'
+
+  def setup
+    PRX::Client.key     = 'keykeykeykeykeykeykeykeykeykeykeykeykeyk'
+    PRX::Client.secret  = 'secretsecretsecretsecretsecretsecretsecr'
     PRX::Client.host    = "development.prx.org"
     PRX::Client.port    = 3001
     PRX::Client.version = 'v2'
-    PRX::Client.token   = 'iW7qgZSQq4ryQRks1G57X7B1appJLOWeF4yZz6jn'
+    PRX::Client.token   = 'tokentokentokentokentokentokentokentoken'
 
     @user_info = {
       :uid      => '1001',
@@ -28,7 +28,7 @@ class PRX::TestClient < Test::Unit::TestCase
 
   def test_me
     stub_request(:get, "http://development.prx.org:3001/me").
-      with(:headers => {'Authorization'=>'Bearer iW7qgZSQq4ryQRks1G57X7B1appJLOWeF4yZz6jn', 'Host'=>'development.prx.org:3001'}).
+      with(:headers => {'Authorization'=>'Bearer tokentokentokentokentokentokentokentoken', 'Host'=>'development.prx.org:3001'}).
       to_return(:status => 200, :body => @user_info.to_json, :headers => {})
 
     response = PRX::Model::User.me
@@ -41,7 +41,7 @@ class PRX::TestClient < Test::Unit::TestCase
                               :description=>'test description',
                               :account=>PRX::Model::Account.new(:id=>8),
                               :producers=>[PRX::Model::Producer.new(:name=>'Producer')])
-                              
+
     p.add_audio(:label=>'test', :attach_file=>"#{File.dirname(__FILE__)}/files/test.mp2", :content_type=>'audio/mpeg')
     # puts p.inspect
 
@@ -52,7 +52,7 @@ class PRX::TestClient < Test::Unit::TestCase
         :headers => {"Content-Length"=>"1118", "Set-Cookie"=>"_prx_session_development=BAh7BzoPc2Vzc2lvbl9pZCIlZDk1NGFmZWQzNDhkZDI4ZDBmMmEzN2YwMzhmZjRiODc6DHVzZXJfaWRpDQ%3D%3D--c307c1d85dacd9d35aead604008e10064684065f; path=/; HttpOnly", "ETag"=>"\"7444da1c82c7cac604f9bc2b94cd6e7b\"", "Cache-Control"=>"private, max-age=0, must-revalidate", "Content-Type"=>"application/json; charset=utf-8", "X-Runtime"=>"985", "Connection"=>"keep-alive"}
       )
 
-    response = PRX::Client.request({:action => :post, :path => 'pieces', :body => p.as_json})
+    response = PRX::Client.request({:action => :post, :path => 'pieces', :body => p.to_hash})
 
     assert response
 
@@ -69,10 +69,10 @@ class PRX::TestClient < Test::Unit::TestCase
       to_return(
         :status => 200,
         :body => "{\"short_description\":\"Episode 12345 of the new Public Radio Remix Select series. Based on Remix 24 episode 54321.\",\"length\":0,\"series\":{\"title\":\"Public Radio Remix Select\",\"id\":32346},\"creator\":{\"first_name\":\"PRX\",\"last_name\":\"Administrator\",\"login\":\"admin\",\"email\":\"admin@prx.org\",\"id\":8},\"publish_on_valid\":true,\"description\":\"this is the description, and it is very long\",\"license\":{\"allow_edit\":\"only with permission\",\"id\":169778,\"website_usage\":\"as a free MP3 download and stream\"},\"promos\":{\"label\":\"Promos\",\"id\":200467,\"audio_files\":[]},\"point_level\":0,\"account_id\":98822,\"title\":\"Remix Select: Episode 12345\",\"id\":88474,\"is_shareable\":true,\"allow_comments\":true,\"episode_number\":12345,\"networks\":[{\"id\":23,\"path\":\"remix-select\",\"name\":\"Public Radio Remix Select\"}],\"account\":{\"id\":98822,\"type\":\"Group\",\"path\":\"remix\",\"name\":\"Public Radio Remix\"},\"network_only\":true,\"producers\":[{\"user\":{\"first_name\":\"PRX\",\"last_name\":\"Administrator\",\"login\":\"admin\",\"email\":\"admin@prx.org\",\"id\":8},\"id\":100458}],\"audio_versions\":[{\"label\":\"Piece Audio\",\"id\":200467,\"audio_files\":[]}],\"created_at\":\"2014-03-18T10:20:11-04:00\"}",
-        :headers => {"Content-Length"=>"1118", "Set-Cookie"=>"_prx_session_development=BAh7BzoPc2Vzc2lvbl9pZCIlZDk1NGFmZWQzNDhkZDI4ZDBmMmEzN2YwMzhmZjRiODc6DHVzZXJfaWRpDQ%3D%3D--c307c1d85dacd9d35aead604008e10064684065f; path=/; HttpOnly", "ETag"=>"\"7444da1c82c7cac604f9bc2b94cd6e7b\"", "Cache-Control"=>"private, max-age=0, must-revalidate", "Content-Type"=>"application/json; charset=utf-8", "X-Runtime"=>"985", "Connection"=>"keep-alive"}
+        :headers => {"Content-Length"=>"1118", "Cache-Control"=>"private, max-age=0, must-revalidate", "Content-Type"=>"application/json; charset=utf-8", "X-Runtime"=>"985", "Connection"=>"keep-alive"}
       )
 
-    response = PRX::Client.request({:action => :post, :path => 'pieces', :body => p.as_json})
+    response = PRX::Client.request({:action => :post, :path => 'pieces', :body => p.to_hash})
 
     assert response
 

--- a/test/test_piece.rb
+++ b/test/test_piece.rb
@@ -13,13 +13,15 @@ class PRX::TestPiece < Test::Unit::TestCase
   end
 
   def test_initialize_with_account_json
-    a = PRX::Model::Piece.from_json({:title=>'t', :id=>1, :account=>{:id=>2}}.to_json)
+    a = PRX::Model::Piece.new.from_json({:title=>'t', :id=>1, :account=>{:id=>2}}.to_json)
     assert a.account.is_a?(PRX::Model::Account)
   end
 
   def test_initialize_with_account_object
-    a = PRX::Model::Piece.from_json({:title=>'t', :id=>1, :account=>PRX::Model::Account.new(:id=>2)}.to_json)
+    json = {:title=>'t', :id=>1, :account=>{id: 2}}.to_json
+    a = PRX::Model::Piece.new.from_json(json)
     assert a.account.is_a?(PRX::Model::Account)
+    assert a.account.id == 2
   end
 
   def test_piece_with_local_file
@@ -64,19 +66,18 @@ class PRX::TestPiece < Test::Unit::TestCase
       :point_level       => 0,
       :publish_on_valid  => true
     )
-    # piece.add_audio(:label=>'audio', :attach_file=>"s3://#{remix_bucket}/#{audio_s3_key}", :size=>1)
+    piece.add_audio(:label=>'audio', :attach_file=>"s3://remix/path/file.mp3", :size=>1)
     # puts "\n\npiece before saved: #{piece.to_json}"
 
-      stub_request(:post, "http://development.prx.org:3001/api/v2/pieces").
-        to_return(
-          :status => 200,
-          :body => "{\"short_description\":\"Episode 12345 of the new Public Radio Remix Select series. Based on Remix 24 episode 54321.\",\"length\":0,\"series\":{\"title\":\"Public Radio Remix Select\",\"id\":32346},\"creator\":{\"first_name\":\"PRX\",\"last_name\":\"Administrator\",\"login\":\"admin\",\"email\":\"admin@prx.org\",\"id\":8},\"publish_on_valid\":true,\"description\":\"this is the description, and it is very long\",\"license\":{\"allow_edit\":\"only with permission\",\"id\":169778,\"website_usage\":\"as a free MP3 download and stream\"},\"promos\":{\"label\":\"Promos\",\"id\":200467,\"audio_files\":[]},\"point_level\":0,\"account_id\":98822,\"title\":\"Remix Select: Episode 12345\",\"id\":88474,\"is_shareable\":true,\"allow_comments\":true,\"episode_number\":12345,\"networks\":[{\"id\":23,\"path\":\"remix-select\",\"name\":\"Public Radio Remix Select\"}],\"account\":{\"id\":98822,\"type\":\"Group\",\"path\":\"remix\",\"name\":\"Public Radio Remix\"},\"network_only\":true,\"producers\":[{\"user\":{\"first_name\":\"PRX\",\"last_name\":\"Administrator\",\"login\":\"admin\",\"email\":\"admin@prx.org\",\"id\":8},\"id\":100458}],\"audio_versions\":[{\"label\":\"Piece Audio\",\"id\":200467,\"audio_files\":[]}],\"created_at\":\"2014-03-18T10:20:11-04:00\"}",
-          :headers => {"Content-Length"=>"1118", "Set-Cookie"=>"_prx_session_development=BAh7BzoPc2Vzc2lvbl9pZCIlZDk1NGFmZWQzNDhkZDI4ZDBmMmEzN2YwMzhmZjRiODc6DHVzZXJfaWRpDQ%3D%3D--c307c1d85dacd9d35aead604008e10064684065f; path=/; HttpOnly", "ETag"=>"\"7444da1c82c7cac604f9bc2b94cd6e7b\"", "Cache-Control"=>"private, max-age=0, must-revalidate", "Content-Type"=>"application/json; charset=utf-8", "X-Runtime"=>"985", "Connection"=>"keep-alive"}
-        )
+    stub_request(:post, "http://development.prx.org:3001/api/v2/pieces").
+      to_return(
+        :status => 200,
+        :body => "{\"short_description\":\"Episode 12345 of the new Public Radio Remix Select series. Based on Remix 24 episode 54321.\",\"length\":0,\"series\":{\"title\":\"Public Radio Remix Select\",\"id\":32346},\"creator\":{\"first_name\":\"PRX\",\"last_name\":\"Administrator\",\"login\":\"admin\",\"email\":\"admin@prx.org\",\"id\":8},\"publish_on_valid\":true,\"description\":\"this is the description, and it is very long\",\"license\":{\"allow_edit\":\"only with permission\",\"id\":169778,\"website_usage\":\"as a free MP3 download and stream\"},\"promos\":{\"label\":\"Promos\",\"id\":200467,\"audio_files\":[]},\"point_level\":0,\"account_id\":98822,\"title\":\"Remix Select: Episode 12345\",\"id\":88474,\"is_shareable\":true,\"allow_comments\":true,\"episode_number\":12345,\"networks\":[{\"id\":23,\"path\":\"remix-select\",\"name\":\"Public Radio Remix Select\"}],\"account\":{\"id\":98822,\"type\":\"Group\",\"path\":\"remix\",\"name\":\"Public Radio Remix\"},\"network_only\":true,\"producers\":[{\"user\":{\"first_name\":\"PRX\",\"last_name\":\"Administrator\",\"login\":\"admin\",\"email\":\"admin@prx.org\",\"id\":8},\"id\":100458}],\"audio_versions\":[{\"label\":\"Piece Audio\",\"id\":200467,\"audio_files\":[]}],\"created_at\":\"2014-03-18T10:20:11-04:00\"}",
+        :headers => {"Content-Length"=>"1118", "Cache-Control"=>"private, max-age=0, must-revalidate", "Content-Type"=>"application/json; charset=utf-8", "X-Runtime"=>"985", "Connection"=>"keep-alive"}
+      )
 
     piece.save
     assert piece.id && (piece.id > 0)
     # puts "\n\npiece after saved:  #{piece.to_json}"
   end
-
 end


### PR DESCRIPTION
`roar` version 1.0 has a breaking change in how modules are named, affecting requires and includes for the representers. This PR fixes that, and gets the code working with rails 4.2, using active_model.